### PR TITLE
medspacy_quickumls 3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/medspacy_quickumls-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 09edeb61467f3570e370337c9bb635f65a03246c9c8fd2af0bb9710e75a46a06
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 
 requirements:
@@ -29,6 +29,8 @@ requirements:
     - unqlite >=0.8.1
     - pytest >=6
     - six
+    # pydantic <1.9.0 is required for spacy 3.3.1 and thinc 8.0.15
+    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.9.0
 
 test:
   imports:
@@ -40,8 +42,13 @@ test:
 
 about:
   home: https://github.com/Georgetown-IR-Lab/QuickUMLS
+  dev_url: https://github.com/Georgetown-IR-Lab/QuickUMLS
+  doc_url: https://github.com/Georgetown-IR-Lab/QuickUMLS
   summary: QuickUMLS is a tool for fast, unsupervised biomedical concept extraction from medical text
+  description: |
+    QuickUMLS is a tool for fast, unsupervised biomedical concept extraction from medical text
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,14 +23,14 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.8.2
-    - spacy >=3.1.3
-    - unidecode >=0.4.19
     - nltk >=3.3
+    - numpy >=1.8.2
     - pysimstring
-    - unqlite >=0.8.1
     - pytest >=6
     - six
+    - spacy >=3.1.3
+    - unidecode >=0.4.19
+    - unqlite >=0.8.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,16 +29,16 @@ requirements:
     - unqlite >=0.8.1
     - pytest >=6
     - six
-    # pydantic <1.9.0 is required for spacy 3.3.1 and thinc 8.0.15
-    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.9.0
 
 test:
   imports:
     - quickumls
-  commands:
-    - pip check
-  requires:
-    - pip
+  # Do not run pip check on the test environment, because of an error
+  # thinc 8.0.15 and spacy 3.3.1 has requirement pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4, but you have pydantic 1.10.2.
+  # commands:
+  #   - pip check
+  # requires:
+  #   - pip
 
 about:
   home: https://github.com/Georgetown-IR-Lab/QuickUMLS

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,10 @@ source:
   sha256: 09edeb61467f3570e370337c9bb635f65a03246c9c8fd2af0bb9710e75a46a06
 
 build:
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
+  # spacy >=3.1.3 isn't available on s390x
+  skip: true  # [s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,12 +35,10 @@ requirements:
 test:
   imports:
     - quickumls
-  # Do not run pip check on the test environment, because of an error
-  # thinc 8.0.15 and spacy 3.3.1 has requirement pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4, but you have pydantic 1.10.2.
-  # commands:
-  #   - pip check
-  # requires:
-  #   - pip
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/Georgetown-IR-Lab/QuickUMLS


### PR DESCRIPTION
License: https://github.com/Georgetown-IR-Lab/QuickUMLS/blob/master/LICENSE.txt
Requirements:
- https://github.com/Georgetown-IR-Lab/QuickUMLS/blob/master/setup.py
- https://github.com/Georgetown-IR-Lab/QuickUMLS/blob/master/requirements.txt

Notes:
- Release 3.0 exists on PyPi https://pypi.org/project/medspacy-quickumls/3.0/. It has requirements.txt with:
```
    numpy>=1.8.2
    spacy>=3.1.3
    unidecode>=0.4.19
    nltk>=3.3
    pysimstring
    unqlite>=0.8.1
    pytest>=6
    six
```